### PR TITLE
Fix the Failure of killdockers() Function on Windows System

### DIFF
--- a/fedstellar/controller.py
+++ b/fedstellar/controller.py
@@ -238,31 +238,42 @@ class Controller:
         os.system(command)
 
     @staticmethod
-    def killdockers():
-        try:
-            # kill all the docker containers which contain the word "fedstellar"
-            command = '''docker kill $(docker ps -q --filter ancestor=fedstellar) > /dev/null 2>&1'''
-            time.sleep(1)
-            os.system(command)
-            command = '''docker rm $(docker ps -a -q --filter ancestor=fedstellar) > /dev/null 2>&1'''
-            time.sleep(1)
-            os.system(command)
+    def killdockers():  # for windows user
+        if sys.platform == "win32":
+            try:
+                # kill all the docker containers which contain the word "fedstellar"
+                commands = [
+                    '''docker kill $(docker ps -q --filter ancestor=fedstellar) | Out-Null''',
+                    '''docker rm $(docker ps -a -q --filter ancestor=fedstellar) | Out-Null''',
+                    '''docker kill $(docker ps -q --filter ancestor=fedstellar-gpu) | Out-Null''',
+                    '''docker rm $(docker ps -a -q --filter ancestor=fedstellar-gpu) | Out-Null''',
+                    '''docker network rm $(docker network ls | Where-Object { ($_ -split '\s+')[1] -like '*fedstellar*' } | ForEach-Object { ($_ -split '\s+')[0] }) | Out-Null'''
+                ]
 
-            # the same but for fedstellar-gpu
-            command = '''docker kill $(docker ps -q --filter ancestor=fedstellar-gpu) > /dev/null 2>&1'''
-            time.sleep(1)
-            os.system(command)
-            command = '''docker rm $(docker ps -a -q --filter ancestor=fedstellar-gpu) > /dev/null 2>&1'''
-            time.sleep(1)
-            os.system(command)
+                for command in commands:
+                    time.sleep(1)
+                    exit_code = os.system(f"powershell.exe -Command \"{command}\"")
+                    logging.info(f"Windows Command '{command}' executed with exit codehhhh: {exit_code}")
 
-            # remove all docker networks which contain the word "fedstellar"
-            command = '''docker network rm $(docker network ls | grep fedstellar | awk '{print $1}') > /dev/null 2>&1'''
-            time.sleep(1)
-            os.system(command)
+            except Exception as e:
+                raise Exception("Error while killing docker containers: {}".format(e))
+        else:
+            try:
+                commands = [
+                    '''docker kill $(docker ps -q --filter ancestor=fedstellar) > /dev/null 2>&1''',
+                    '''docker rm $(docker ps -a -q --filter ancestor=fedstellar) > /dev/null 2>&1''',
+                    '''docker kill $(docker ps -q --filter ancestor=fedstellar-gpu) > /dev/null 2>&1''',
+                    '''docker rm $(docker ps -a -q --filter ancestor=fedstellar-gpu) > /dev/null 2>&1''',
+                    '''docker network rm $(docker network ls | grep fedstellar | awk '{print $1}') > /dev/null 2>&1'''
+                ]
 
-        except Exception as e:
-            raise Exception("Error while killing docker containers: {}".format(e))
+                for command in commands:
+                    time.sleep(1)
+                    exit_code = os.system(command)
+                    logging.info(f"Linux Command '{command}' executed with exit codehhhh: {exit_code}")
+
+            except Exception as e:
+                raise Exception("Error while killing docker containers: {}".format(e))
 
     def load_configurations_and_start_nodes(self):
         if not self.scenario_name:


### PR DESCRIPTION
Dear Enrique, 
         When using fedstellar recently, I noticed that the **killdockers() function** was not run correctly on Windows systems, resulting in the need to manually handle the corresponding docker container and network every time. After investigation, I think the problem lies in the fact that **the original docker command is not suitable for the Windows cmd command**. In other words, $( ) this command substitution cannot be used in Windows cmd but can be run well on Powshell. Thus I add the powshell.exe -command before each command and also change the last command a bit (since grep even not work in Powshell). Then, it successfully run on my computer and automatically deal with all the containers and network after stopping each scenario.
                                                                                                                                                                                UZH Yuanzhe Gao